### PR TITLE
doc: add note about return value of `statement/execute` #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bugfix
 
  * rename keyowrd -> keyword #2 (@jasalt)
+ * doc: add note about return value of `statement/execute` #3
 
 ## v0.0.7 (2024-06-24)
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ Returns an SQL prepared command
 
 Executes a prepared statement
 
+> [!NOTE]
+> The return value of the original library, `PDOStatement::execute()`, is a `bool` value representing the result of the `execute` method, while the return value of `statement/execute` returns the statement itself.
+
 ```clojure
 (execute statement)
 ```


### PR DESCRIPTION
close #3