### PR TITLE
fix require phel-lang version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG
 
-
 ### Bugfix
 
  * rename keyowrd -> keyword #2 (@jasalt)
  * doc: add note about return value of `statement/execute` #3
+ * fix require phel-lang version.
 
 ## v0.0.7 (2024-06-24)
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "phel-lang/phel-lang": ">=0.15"
+        "phel-lang/phel-lang": ">=0.15 <1.0"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "phel-lang/phel-lang": "^0.15"
+        "phel-lang/phel-lang": ">=0.15"
     },
     "license": "MIT",
     "autoload": {


### PR DESCRIPTION
Changed phel-lang dependency version specification from `“phel-lang/phel-lang”:“^0.15”` to `“phel-lang/phel-lang”:“>=0.15 <1.0”`.

This will support phel-lang 0.17.