### PR TITLE
feat(pdo): add insert taking a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `pdo/insert` — build an `INSERT` from a map (`(pdo/insert conn :table {:col v ...})`), execute it as a prepared statement, and return the new `last-insert-id`. Identifiers must match `[A-Za-z_][A-Za-z0-9_]*` ([#4]).
+
 ## [0.1.0] - 2026-05-13
 
 ### Changed
@@ -97,3 +101,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1]: https://github.com/phel-lang/phel-pdo/issues/1
 [#2]: https://github.com/phel-lang/phel-pdo/pull/2
 [#3]: https://github.com/phel-lang/phel-pdo/issues/3
+[#4]: https://github.com/phel-lang/phel-pdo/issues/4

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Requires PHP `>=8.4` and `phel-lang/phel-lang ^0.37`.
     (pdo/execute {:id 1})
     (pdo/fetch))
 ;; => {:id 1 :name "phel"}
+
+;; Insert a row from a map
+(pdo/insert conn :t1 {:name "lisp"})
+;; => 3   ; new last-insert-id
 ```
 
 `pdo/fetch` returns the row as a map keyed by column keyword, or `nil` when no rows remain.
@@ -69,6 +73,7 @@ All functions live in the `phel.pdo` namespace.
 | `exec` | `(exec conn sql)` | Execute SQL, return number of affected rows. |
 | `query` | `(query conn sql & [fetch-mode])` | Run SQL without placeholders, return a statement. |
 | `prepare` | `(prepare conn sql & [options])` | Prepare a statement for later `execute`. |
+| `insert` | `(insert conn table row)` | Insert `row` into `table` via a prepared statement and return the new `last-insert-id`. Identifiers must match `[A-Za-z_][A-Za-z0-9_]*`. |
 | `quote` | `(quote conn string & [type])` | Quote a string for safe embedding in SQL. |
 | `last-insert-id` | `(last-insert-id conn)` | ID of the last inserted row. |
 | `begin` / `commit` / `rollback` | `(begin conn)` … | Transaction control. |

--- a/src/pdo.phel
+++ b/src/pdo.phel
@@ -77,13 +77,12 @@
   "Inserts a row built from a map into table and returns the new last-insert-id.
   Table and column names must be plain identifiers; values are bound as parameters."
   [conn table row]
-  (let [tbl    (check-ident (name table))
-        cols   (into [] (for [k :in (keys row)] (check-ident (name k))))
-        sql    (str "INSERT INTO " tbl
-                    " (" (join-csv cols) ")"
-                    " VALUES (" (join-csv (for [c :in cols] (str ":" c))) ")")
-        params (into {} (for [[k v] :pairs row] [(keyword (name k)) v]))]
-    (-> (prepare conn sql) (execute params))
+  (let [tbl  (check-ident (name table))
+        cols (into [] (for [k :in (keys row)] (check-ident (name k))))
+        sql  (str "INSERT INTO " tbl
+                  " (" (join-csv cols) ")"
+                  " VALUES (" (join-csv (for [c :in cols] (str ":" c))) ")")]
+    (-> (prepare conn sql) (execute row))
     (last-insert-id conn)))
 
 (defn ^int error-code

--- a/src/pdo.phel
+++ b/src/pdo.phel
@@ -26,6 +26,7 @@
   (php/-> (conn :pdo) (exec stmt)))
 
 (declare statement)
+(declare execute)
 
 (defn prepare
   "Prepares a statement for execution and returns a statement object"
@@ -63,6 +64,27 @@
   "Returns the ID of the last inserted row or sequence value"
   [conn]
   (php/intval (php/-> (conn :pdo) (lastInsertId))))
+
+(defn- check-ident [s]
+  (if (= 1 (php/preg_match "/^[A-Za-z_][A-Za-z0-9_]*$/" s))
+    s
+    (throw (php/new \InvalidArgumentException (str "Invalid identifier: " s)))))
+
+(defn- join-csv [xs]
+  (php/implode ", " (phel->php (into [] xs))))
+
+(defn ^int insert
+  "Inserts a row built from a map into table and returns the new last-insert-id.
+  Table and column names must be plain identifiers; values are bound as parameters."
+  [conn table row]
+  (let [tbl    (check-ident (name table))
+        cols   (into [] (for [k :in (keys row)] (check-ident (name k))))
+        sql    (str "INSERT INTO " tbl
+                    " (" (join-csv cols) ")"
+                    " VALUES (" (join-csv (for [c :in cols] (str ":" c))) ")")
+        params (into {} (for [[k v] :pairs row] [(keyword (name k)) v]))]
+    (-> (prepare conn sql) (execute params))
+    (last-insert-id conn)))
 
 (defn ^int error-code
   "Fetch the SQLSTATE associated with the last operation on the database handle"

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -158,6 +158,58 @@
     (is (= "SQL: [35] select * from t1 where name = :name" (lines 0)))))
 
 ;; ------
+;; Insert
+;; ------
+
+(deftest insert-returns-new-row-id
+  (create-t1 *conn*)
+  (is (= 1 (pdo/insert *conn* :t1 {:name "phel"}))))
+
+(deftest insert-persists-row
+  (create-t1 *conn*)
+  (pdo/insert *conn* :t1 {:name "phel"})
+  (is (= {:id 1 :name "phel"}
+         (pdo/fetch (pdo/query *conn* "select * from t1 where id = 1")))))
+
+(deftest insert-accepts-string-table
+  (create-t1 *conn*)
+  (is (= 1 (pdo/insert *conn* "t1" {:name "phel"}))))
+
+(deftest insert-monotonic-ids
+  (create-t1 *conn*)
+  (pdo/insert *conn* :t1 {:name "a"})
+  (is (= 2 (pdo/insert *conn* :t1 {:name "b"}))))
+
+(deftest insert-rejects-bad-table
+  (create-t1 *conn*)
+  (let [thrown (try
+                 (pdo/insert *conn* "t1; drop table t1" {:name "x"})
+                 false
+                 (catch \InvalidArgumentException _e true))]
+    (is (= true thrown))))
+
+(deftest insert-rejects-bad-column
+  (create-t1 *conn*)
+  (let [thrown (try
+                 (pdo/insert *conn* :t1 {"name) --" "x"})
+                 false
+                 (catch \InvalidArgumentException _e true))]
+    (is (= true thrown))))
+
+(deftest insert-binds-values-safely
+  (create-t1 *conn*)
+  (pdo/insert *conn* :t1 {:name "'; drop table t1; --"})
+  (is (= "'; drop table t1; --"
+         (pdo/fetch-column (pdo/query *conn* "select name from t1 where id = 1")))))
+
+(deftest insert-rolls-back-inside-transaction
+  (create-t1 *conn*)
+  (pdo/begin *conn*)
+  (pdo/insert *conn* :t1 {:name "tmp"})
+  (pdo/rollback *conn*)
+  (is (= 0 (pdo/fetch-column (pdo/query *conn* "select count(*) from t1")))))
+
+;; ------
 ;; Errors
 ;; ------
 


### PR DESCRIPTION
## Summary

- `pdo/insert` builds an `INSERT` from a Phel map (`(pdo/insert conn :table {:col v ...})`), runs it through `prepare`/`execute`, and returns the new `last-insert-id`.
- Table and column names are validated against `[A-Za-z_][A-Za-z0-9_]*`; bad identifiers throw `\InvalidArgumentException` before any SQL is built.
- Values stay user-supplied; they ride through the prepared statement's bound params.

Polish pass on top: dropped a redundant kw-keyed rebuild — `pdo/execute` already runs the map through `phel->php`.

Closes #4

## Test plan

- [x] `composer test` — 32/32 (added: `insert-returns-new-row-id`, `insert-persists-row`, `insert-accepts-string-table`, `insert-monotonic-ids`, `insert-rejects-bad-table`, `insert-rejects-bad-column`, `insert-binds-values-safely`, `insert-rolls-back-inside-transaction`).
- [x] Injection guard: `"'; drop table t1; --"` lands verbatim in the row, table unaffected.