### PR TITLE
chore: apply phel 0.41 formatting

### DIFF
--- a/src/pdo.phel
+++ b/src/pdo.phel
@@ -32,13 +32,13 @@
   "Prepares a statement for execution and returns a statement object"
   [conn stmt & [options]]
   (statement
-    (php/-> (conn :pdo) (prepare stmt (phel->php (or options {}))))))
+   (php/-> (conn :pdo) (prepare stmt (phel->php (or options {}))))))
 
 (defn query
   "Prepares and executes an SQL statement without placeholders"
   [conn stmt & [fetch-mode]]
   (statement
-    (php/-> (conn :pdo) (query stmt (or fetch-mode \PDO/FETCH_ASSOC)))))
+   (php/-> (conn :pdo) (query stmt (or fetch-mode \PDO/FETCH_ASSOC)))))
 
 (defn ^bool begin
   "Initiates a transaction"

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -68,13 +68,13 @@
 
 (deftest in-transaction-tracks-state
   (testing "false outside transaction"
-    (is (= false (pdo/in-transaction *conn*))))
+           (is (= false (pdo/in-transaction *conn*))))
   (testing "true after begin"
-    (pdo/begin *conn*)
-    (is (= true (pdo/in-transaction *conn*))))
+           (pdo/begin *conn*)
+           (is (= true (pdo/in-transaction *conn*))))
   (testing "false after commit"
-    (pdo/commit *conn*)
-    (is (= false (pdo/in-transaction *conn*)))))
+           (pdo/commit *conn*)
+           (is (= false (pdo/in-transaction *conn*)))))
 
 (deftest commit-persists-changes
   (create-t1 *conn*)
@@ -134,20 +134,20 @@
 (deftest bind-value
   (seed-t1 *conn*)
   (testing "default (string) type"
-    (let [stmt (pdo/prepare *conn* "select * from t1 where id = :id")
-          stmt (pdo/bind-value stmt :id 1)
-          stmt (pdo/execute stmt)]
-      (is (= {:id 1 :name "phel"} (pdo/fetch stmt)))))
+           (let [stmt (pdo/prepare *conn* "select * from t1 where id = :id")
+                 stmt (pdo/bind-value stmt :id 1)
+                 stmt (pdo/execute stmt)]
+             (is (= {:id 1 :name "phel"} (pdo/fetch stmt)))))
   (testing "explicit int type"
-    (let [stmt (pdo/prepare *conn* "select * from t1 where id = :id")
-          stmt (pdo/bind-value stmt :id 1 \PDO/PARAM_INT)
-          stmt (pdo/execute stmt)]
-      (is (= {:id 1 :name "phel"} (pdo/fetch stmt)))))
+           (let [stmt (pdo/prepare *conn* "select * from t1 where id = :id")
+                 stmt (pdo/bind-value stmt :id 1 \PDO/PARAM_INT)
+                 stmt (pdo/execute stmt)]
+             (is (= {:id 1 :name "phel"} (pdo/fetch stmt)))))
   (testing "explicit string type"
-    (let [stmt (pdo/prepare *conn* "select * from t1 where name = :name")
-          stmt (pdo/bind-value stmt :name "phel" \PDO/PARAM_STR)
-          stmt (pdo/execute stmt)]
-      (is (= {:id 1 :name "phel"} (pdo/fetch stmt))))))
+           (let [stmt (pdo/prepare *conn* "select * from t1 where name = :name")
+                 stmt (pdo/bind-value stmt :name "phel" \PDO/PARAM_STR)
+                 stmt (pdo/execute stmt)]
+             (is (= {:id 1 :name "phel"} (pdo/fetch stmt))))))
 
 (deftest debug-dump-params-emits-sql-header
   (seed-t1 *conn*)


### PR DESCRIPTION
Normalize `src/pdo.phel` and `tests/pdo_test.phel` to the `phel 0.41` formatter output (indentation only, no behaviour change).

Landed first so the upcoming wrapper PRs (#8-#21) carry focused diffs instead of incidental reformat churn.

`composer test` green (32 tests).