### PR TITLE
feat(pdo): add bind-param statement wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `pdo/insert` - build an `INSERT` from a map (`(pdo/insert conn :table {:col v ...})`), execute it as a prepared statement, and return the new `last-insert-id`. Identifiers must match `[A-Za-z_][A-Za-z0-9_]*` ([#4]).
+- `pdo/bind-param` - wrap `PDOStatement::bindParam`; binds a parameter applied at execution time ([#8]).
 
 ## [0.1.0] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Returned by `pdo/query` and `pdo/prepare`.
 | `fetch-all` | `(fetch-all stmt)` | Remaining rows as a vector of maps. |
 | `fetch-column` | `(fetch-column stmt & [column])` | Single column from the next row. |
 | `bind-value` | `(bind-value stmt column value & [type])` | Bind a value to a placeholder. Returns the statement. |
+| `bind-param` | `(bind-param stmt column value & [type])` | Bind a parameter, applied at execution time. Returns the statement. |
 | `column-count` | `(column-count stmt)` | Number of columns in the result set. |
 | `row-count` | `(row-count stmt)` | Rows affected by the last DML. |
 | `debug-dump-params` | `(debug-dump-params stmt)` | Dump prepared statement info as a string. |

--- a/src/pdo/statement.phel
+++ b/src/pdo/statement.phel
@@ -46,6 +46,13 @@
           (bindValue (str column) value (or type \PDO/PARAM_STR)))
   stmt)
 
+(defn bind-param
+  "Binds a parameter to a value, applied at execution time"
+  [stmt column value & [type]]
+  (php/-> (stmt :stmt)
+          (bindParam (str column) value (or type \PDO/PARAM_STR)))
+  stmt)
+
 (defn ^string debug-dump-params
   "Returns an SQL prepared command"
   [stmt]
@@ -56,7 +63,6 @@
 ;; Not implemented yet:
 ;;
 ;; PDOStatement::bindColumn      — Bind a column to a PHP variable
-;; PDOStatement::bindParam       — Binds a parameter to the specified variable name
 ;; PDOStatement::closeCursor     — Closes the cursor, enabling the statement to be executed again
 ;; PDOStatement::errorCode       — Fetch the SQLSTATE associated with the last operation on the statement handle
 ;; PDOStatement::errorInfo       — Fetch extended error information associated with the last operation on the statement handle

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -149,6 +149,19 @@
                  stmt (pdo/execute stmt)]
              (is (= {:id 1 :name "phel"} (pdo/fetch stmt))))))
 
+(deftest bind-param
+  (seed-t1 *conn*)
+  (testing "default (string) type"
+           (let [stmt (pdo/prepare *conn* "select * from t1 where id = :id")
+                 stmt (pdo/bind-param stmt :id 1)
+                 stmt (pdo/execute stmt)]
+             (is (= {:id 1 :name "phel"} (pdo/fetch stmt)))))
+  (testing "explicit int type"
+           (let [stmt (pdo/prepare *conn* "select * from t1 where id = :id")
+                 stmt (pdo/bind-param stmt :id 1 \PDO/PARAM_INT)
+                 stmt (pdo/execute stmt)]
+             (is (= {:id 1 :name "phel"} (pdo/fetch stmt))))))
+
 (deftest debug-dump-params-emits-sql-header
   (seed-t1 *conn*)
   (let [stmt  (pdo/prepare *conn* "select * from t1 where name = :name")


### PR DESCRIPTION
Wraps `PDOStatement::bindParam` as `pdo/bind-param`, mirroring the existing `bind-value` signature: `(bind-param stmt column value & [type])`, defaulting `type` to `\PDO/PARAM_STR` and returning the statement so it threads through `->`.

Phel values are immutable, so there is no by-reference variable to track; the bound value is applied at execution time like `bind-value`. Kept the signature/return identical to `bind-value` for API symmetry.

- Removed from the "Not implemented yet" block in `src/pdo/statement.phel`.
- Test `bind-param` (default + explicit int type) added to `tests/pdo_test.phel`.
- README API table + CHANGELOG `## [Unreleased]` updated.

Polish pass: no refactor needed - the wrapper is a direct peer of `bind-value`.

`composer test` green (34 tests).

Closes #8