### PR TITLE
feat(pdo): add close-cursor statement wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pdo/insert` - build an `INSERT` from a map (`(pdo/insert conn :table {:col v ...})`), execute it as a prepared statement, and return the new `last-insert-id`. Identifiers must match `[A-Za-z_][A-Za-z0-9_]*` ([#4]).
 - `pdo/bind-param` - wrap `PDOStatement::bindParam`; binds a parameter applied at execution time ([#8]).
+- `pdo/close-cursor` - wrap `PDOStatement::closeCursor`; frees the cursor so the statement can be re-executed ([#9]).
 
 ## [0.1.0] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Returned by `pdo/query` and `pdo/prepare`.
 | `bind-param` | `(bind-param stmt column value & [type])` | Bind a parameter, applied at execution time. Returns the statement. |
 | `column-count` | `(column-count stmt)` | Number of columns in the result set. |
 | `row-count` | `(row-count stmt)` | Rows affected by the last DML. |
+| `close-cursor` | `(close-cursor stmt)` | Free the cursor so the statement can be re-executed. Returns the statement. |
 | `debug-dump-params` | `(debug-dump-params stmt)` | Dump prepared statement info as a string. |
 
 > [!NOTE]

--- a/src/pdo/statement.phel
+++ b/src/pdo/statement.phel
@@ -29,6 +29,12 @@
     (php/-> (stmt :stmt) (execute (phel->php params))))
   stmt)
 
+(defn close-cursor
+  "Closes the cursor, enabling the statement to be executed again"
+  [stmt]
+  (php/-> (stmt :stmt) (closeCursor))
+  stmt)
+
 (defn ^int column-count
   "Returns the number of columns in the result set"
   [stmt]
@@ -63,7 +69,6 @@
 ;; Not implemented yet:
 ;;
 ;; PDOStatement::bindColumn      — Bind a column to a PHP variable
-;; PDOStatement::closeCursor     — Closes the cursor, enabling the statement to be executed again
 ;; PDOStatement::errorCode       — Fetch the SQLSTATE associated with the last operation on the statement handle
 ;; PDOStatement::errorInfo       — Fetch extended error information associated with the last operation on the statement handle
 ;; PDOStatement::fetchObject     — Fetches the next row and returns it as an object

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -162,6 +162,15 @@
                  stmt (pdo/execute stmt)]
              (is (= {:id 1 :name "phel"} (pdo/fetch stmt))))))
 
+(deftest close-cursor-allows-re-execution
+  (seed-t1 *conn*)
+  (let [stmt (pdo/prepare *conn* "select name from t1 where id = :id")
+        stmt (pdo/execute stmt {:id 1})
+        _    (pdo/fetch stmt)
+        stmt (pdo/close-cursor stmt)
+        stmt (pdo/execute stmt {:id 1})]
+    (is (= "phel" (pdo/fetch-column stmt)))))
+
 (deftest debug-dump-params-emits-sql-header
   (seed-t1 *conn*)
   (let [stmt  (pdo/prepare *conn* "select * from t1 where name = :name")


### PR DESCRIPTION
Wraps `PDOStatement::closeCursor` as `pdo/close-cursor`. Frees the cursor so the same prepared statement can be executed again; returns the statement so it threads through `->`.

- Removed from the "Not implemented yet" block in `src/pdo/statement.phel`.
- Test `close-cursor-allows-re-execution`: execute, fetch, close-cursor, re-execute, assert second result.
- README API table + CHANGELOG `## [Unreleased]` updated.

Polish pass: no refactor needed - mutator-style wrapper consistent with `execute`/`bind-value`.

`composer test` green (35 tests).

Closes #9