### PR TITLE
feat(pdo): add set-fetch-mode statement wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pdo/bind-param` - wrap `PDOStatement::bindParam`; binds a parameter applied at execution time ([#8]).
 - `pdo/close-cursor` - wrap `PDOStatement::closeCursor`; frees the cursor so the statement can be re-executed ([#9]).
 - `pdo/fetch-object` - wrap `PDOStatement::fetchObject`; returns the next row as an object (`stdClass` or a named class), or `nil` when exhausted ([#11]).
+- `pdo/set-fetch-mode` - wrap `PDOStatement::setFetchMode`; sets the statement's default fetch mode, with mode-specific extra args ([#13]).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Returned by `pdo/query` and `pdo/prepare`.
 | `column-count` | `(column-count stmt)` | Number of columns in the result set. |
 | `row-count` | `(row-count stmt)` | Rows affected by the last DML. |
 | `close-cursor` | `(close-cursor stmt)` | Free the cursor so the statement can be re-executed. Returns the statement. |
+| `set-fetch-mode` | `(set-fetch-mode stmt mode & args)` | Set the statement's default fetch mode (extra args match the mode). Returns the statement. |
 | `debug-dump-params` | `(debug-dump-params stmt)` | Dump prepared statement info as a string. |
 
 > [!NOTE]

--- a/src/pdo/statement.phel
+++ b/src/pdo/statement.phel
@@ -43,6 +43,17 @@
   (php/-> (stmt :stmt) (closeCursor))
   stmt)
 
+(defn set-fetch-mode
+  "Sets the default fetch mode for the statement. Extra args match the mode
+  (e.g. column index for FETCH_COLUMN, class name + ctor args for FETCH_CLASS)"
+  [stmt mode & args]
+  (let [s (stmt :stmt)]
+    (case (count args)
+      0 (php/-> s (setFetchMode mode))
+      1 (php/-> s (setFetchMode mode (phel->php (first args))))
+      2 (php/-> s (setFetchMode mode (phel->php (first args)) (phel->php (second args))))))
+  stmt)
+
 (defn ^int column-count
   "Returns the number of columns in the result set"
   [stmt]
@@ -82,4 +93,3 @@
 ;; PDOStatement::getColumnMeta   — Returns metadata for a column in a result set
 ;; PDOStatement::getIterator     — Gets result set iterator
 ;; PDOStatement::nextRowset      — Advances to the next rowset in a multi-rowset statement handle
-;; PDOStatement::setFetchMode    — Set the default fetch mode for this statement

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -183,6 +183,20 @@
         stmt (pdo/execute stmt {:id 1})]
     (is (= "phel" (pdo/fetch-column stmt)))))
 
+(deftest set-fetch-mode-column-returns-scalar
+  (seed-t1 *conn*)
+  (let [stmt (pdo/prepare *conn* "select name from t1")
+        stmt (pdo/set-fetch-mode stmt \PDO/FETCH_COLUMN 0)
+        stmt (pdo/execute stmt)]
+    (is (= "phel" (php/-> (stmt :stmt) (fetch))))))
+
+(deftest set-fetch-mode-num-returns-positional-row
+  (seed-t1 *conn*)
+  (let [stmt (pdo/prepare *conn* "select id, name from t1")
+        stmt (pdo/set-fetch-mode stmt \PDO/FETCH_NUM)
+        stmt (pdo/execute stmt)]
+    (is (= [1 "phel"] (php->phel (php/-> (stmt :stmt) (fetch)))))))
+
 (deftest set-attribute-dispatches-to-statement
   (seed-t1 *conn*)
   ;; SQLite rejects statement attributes; depending on the driver build this is


### PR DESCRIPTION
Wraps `PDOStatement::setFetchMode` as `pdo/set-fetch-mode`: `(set-fetch-mode stmt mode & args)`. Dispatches on the number of extra args to cover all PDO arities (mode alone; `+ colno` for `FETCH_COLUMN`; `+ class + ctor-args` for `FETCH_CLASS`/`FETCH_INTO`). Extra args go through `phel->php`, and the statement is returned so it threads through `->`.

- Removed from the "Not implemented yet" block in `src/pdo/statement.phel`.
- Tests: `set-fetch-mode-column-returns-scalar` (`FETCH_COLUMN`) and `set-fetch-mode-num-returns-positional-row` (`FETCH_NUM`). They read through the raw `fetch` because `pdo/fetch` always requests `FETCH_ASSOC`.
- README API table + CHANGELOG `## [Unreleased]` updated.

Polish pass: no refactor needed - `case` on arg count keeps the variadic dispatch flat.

`composer test` green (43 assertions).

Closes #13