### PR TITLE
feat(pdo): statement-level error-code/error-info via polymorphic dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `pdo/get-attribute` / `pdo/set-attribute` now dispatch on the handle: pass a connection (as before) or a statement to reach `PDOStatement::getAttribute` / `setAttribute` ([#12]).
+- `pdo/error-code` / `pdo/error-info` now dispatch on the handle: pass a statement to read `PDOStatement::errorCode` / `errorInfo` ([#14]).
 
 ## [0.1.0] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ All functions live in the `phel.pdo` namespace.
 | `in-transaction` | `(in-transaction conn)` | `true` if a transaction is active. |
 | `get-attribute` / `set-attribute` | `(get-attribute handle attr)` / `(set-attribute handle attr value)` | PDO attribute access; `handle` is a connection or a statement. |
 | `get-available-drivers` | `(get-available-drivers conn)` | Vector of installed PDO drivers. |
-| `error-code` | `(error-code conn)` | SQLSTATE of the last operation. |
-| `error-info` | `(error-info conn)` | `[sqlstate driver-code driver-message]`. |
+| `error-code` | `(error-code handle)` | SQLSTATE of the last operation; `handle` is a connection or a statement. |
+| `error-info` | `(error-info handle)` | `[sqlstate driver-code driver-message]`; `handle` is a connection or a statement. |
 
 ### Statement
 

--- a/src/pdo.phel
+++ b/src/pdo.phel
@@ -4,20 +4,20 @@
 
 (declare statement?)
 
-(defn- attr-target
-  "The PDO handle behind a connection or statement struct."
+(defn- handle-target
+  "The raw PDO handle behind a connection or statement struct."
   [handle]
   (if (statement? handle) (handle :stmt) (handle :pdo)))
 
 (defn ^bool set-attribute
   "Set an attribute on a connection or statement"
   [handle attribute value]
-  (php/-> (attr-target handle) (setAttribute attribute value)))
+  (php/-> (handle-target handle) (setAttribute attribute value)))
 
 (defn get-attribute
   "Retrieve an attribute from a connection or statement"
   [handle attribute]
-  (php/-> (attr-target handle) (getAttribute attribute)))
+  (php/-> (handle-target handle) (getAttribute attribute)))
 
 (defn connect
   "Connect database and return connection object.
@@ -93,15 +93,15 @@
     (last-insert-id conn)))
 
 (defn ^int error-code
-  "Fetch the SQLSTATE associated with the last operation on the database handle"
-  [conn]
-  (php/intval (php/-> (conn :pdo) (errorCode))))
+  "Fetch the SQLSTATE associated with the last operation on a connection or statement"
+  [handle]
+  (php/intval (php/-> (handle-target handle) (errorCode))))
 
 (defn error-info
-  "Fetch extended error information associated with the last operation on the database handle"
-  [conn]
+  "Fetch extended error information associated with the last operation on a connection or statement"
+  [handle]
   (let [[sqlstate driver-code driver-message]
-        (values (php->phel (php/-> (conn :pdo) (errorInfo))))]
+        (values (php->phel (php/-> (handle-target handle) (errorInfo))))]
     [(php/intval sqlstate) (php/intval driver-code) driver-message]))
 
 (defn ^bool in-transaction

--- a/src/pdo/statement.phel
+++ b/src/pdo/statement.phel
@@ -88,8 +88,6 @@
 ;; Not implemented yet:
 ;;
 ;; PDOStatement::bindColumn      — Bind a column to a PHP variable
-;; PDOStatement::errorCode       — Fetch the SQLSTATE associated with the last operation on the statement handle
-;; PDOStatement::errorInfo       — Fetch extended error information associated with the last operation on the statement handle
 ;; PDOStatement::getColumnMeta   — Returns metadata for a column in a result set
 ;; PDOStatement::getIterator     — Gets result set iterator
 ;; PDOStatement::nextRowset      — Advances to the next rowset in a multi-rowset statement handle

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -296,3 +296,19 @@
     (pdo/exec *conn* "insert into t1 (id, name) values (1, 'php')")
     (catch \PDOException _e nil))
   (is (= [23000 19 "UNIQUE constraint failed: t1.id"] (pdo/error-info *conn*))))
+
+(deftest statement-error-code-on-constraint-violation
+  (seed-t1 *conn*)
+  (let [stmt (pdo/prepare *conn* "insert into t1 (id, name) values (1, 'php')")]
+    (try
+      (pdo/execute stmt)
+      (catch \PDOException _e nil))
+    (is (= 23000 (pdo/error-code stmt)))))
+
+(deftest statement-error-info-on-constraint-violation
+  (seed-t1 *conn*)
+  (let [stmt (pdo/prepare *conn* "insert into t1 (id, name) values (1, 'php')")]
+    (try
+      (pdo/execute stmt)
+      (catch \PDOException _e nil))
+    (is (= [23000 19 "UNIQUE constraint failed: t1.id"] (pdo/error-info stmt)))))


### PR DESCRIPTION
Wraps `PDOStatement::errorCode` / `errorInfo`. Same approach as #12: instead of new names colliding in the single `phel.pdo` namespace, `error-code` / `error-info` now dispatch on the handle.

```phel
(pdo/error-code conn)   ;; connection (unchanged)
(pdo/error-code stmt)   ;; statement
```

Generalized the `attr-target` helper from #12 into `handle-target` (resolves `:pdo` vs `:stmt`), now shared by the attribute and error accessors.

- Removed both methods from the "Not implemented yet" block in `src/pdo/statement.phel`.
- Tests: `statement-error-code-on-constraint-violation` and `statement-error-info-on-constraint-violation`, mirroring the existing connection-level error tests (UNIQUE violation via a prepared statement). Existing connection error tests still green.
- README + CHANGELOG (`### Changed`) updated.

Polish pass: renamed `attr-target` -> `handle-target` and reused it, so error and attribute accessors share one resolver.

`composer test` green (45 assertions).

Closes #14