### PR TITLE
feat(pdo): add column-meta statement wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pdo/close-cursor` - wrap `PDOStatement::closeCursor`; frees the cursor so the statement can be re-executed ([#9]).
 - `pdo/fetch-object` - wrap `PDOStatement::fetchObject`; returns the next row as an object (`stdClass` or a named class), or `nil` when exhausted ([#11]).
 - `pdo/set-fetch-mode` - wrap `PDOStatement::setFetchMode`; sets the statement's default fetch mode, with mode-specific extra args ([#13]).
+- `pdo/column-meta` - wrap `PDOStatement::getColumnMeta`; returns a 0-indexed column's metadata as a map, or `nil` when unavailable ([#15]).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Returned by `pdo/query` and `pdo/prepare`.
 | `bind-param` | `(bind-param stmt column value & [type])` | Bind a parameter, applied at execution time. Returns the statement. |
 | `column-count` | `(column-count stmt)` | Number of columns in the result set. |
 | `row-count` | `(row-count stmt)` | Rows affected by the last DML. |
+| `column-meta` | `(column-meta stmt column)` | Metadata map for a 0-indexed column, or `nil` if unavailable. |
 | `close-cursor` | `(close-cursor stmt)` | Free the cursor so the statement can be re-executed. Returns the statement. |
 | `set-fetch-mode` | `(set-fetch-mode stmt mode & args)` | Set the statement's default fetch mode (extra args match the mode). Returns the statement. |
 | `debug-dump-params` | `(debug-dump-params stmt)` | Dump prepared statement info as a string. |

--- a/src/pdo/statement.phel
+++ b/src/pdo/statement.phel
@@ -64,6 +64,12 @@
   [stmt]
   (php/-> (stmt :stmt) (rowCount)))
 
+(defn column-meta
+  "Returns metadata for a 0-indexed column in the result set as a map, or nil if unavailable"
+  [stmt column]
+  (when-let [meta (php/-> (stmt :stmt) (getColumnMeta column))]
+    (row->map meta)))
+
 (defn bind-value
   "Binds a value to a parameter"
   [stmt column value & [type]]
@@ -88,6 +94,5 @@
 ;; Not implemented yet:
 ;;
 ;; PDOStatement::bindColumn      — Bind a column to a PHP variable
-;; PDOStatement::getColumnMeta   — Returns metadata for a column in a result set
 ;; PDOStatement::getIterator     — Gets result set iterator
 ;; PDOStatement::nextRowset      — Advances to the next rowset in a multi-rowset statement handle

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -128,6 +128,13 @@
   (let [stmt (pdo/query *conn* "select * from t1")]
     (is (= 2 (pdo/column-count stmt)))))
 
+(deftest column-meta-returns-map
+  (seed-t1 *conn*)
+  (let [stmt (pdo/query *conn* "select id, name from t1")
+        meta (pdo/column-meta stmt 1)]
+    (is (= "name" (meta :name)))
+    (is (= "t1" (meta :table)))))
+
 (deftest row-count-on-insert
   (create-t1 *conn*)
   (let [stmt (pdo/query *conn* "insert into t1 (name) values ('phel'), ('php')")]


### PR DESCRIPTION
Wraps `PDOStatement::getColumnMeta` as `pdo/column-meta`: `(column-meta stmt column)`. Returns the column's metadata as a map (keys keywordised via the existing `row->map`), or `nil` when no metadata is available (`getColumnMeta` returned `false`).

```phel
(pdo/column-meta stmt 1)
;; => {:name "name" :table "t1" :pdo_type 2 :len -1 :precision 0 ...}
```

- Removed from the "Not implemented yet" block in `src/pdo/statement.phel`.
- Test `column-meta-returns-map` asserts the driver-stable `:name` and `:table` keys (other keys vary by driver/version, so they are not asserted).
- README API table + CHANGELOG `## [Unreleased]` updated.

Polish pass: no refactor needed - reuses `row->map`, consistent with the other readers.

`composer test` green (47 assertions).

Closes #15