### PR TITLE
feat(pdo): expose statement rows as a lazy seq (statement-seq)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pdo/fetch-object` - wrap `PDOStatement::fetchObject`; returns the next row as an object (`stdClass` or a named class), or `nil` when exhausted ([#11]).
 - `pdo/set-fetch-mode` - wrap `PDOStatement::setFetchMode`; sets the statement's default fetch mode, with mode-specific extra args ([#13]).
 - `pdo/column-meta` - wrap `PDOStatement::getColumnMeta`; returns a 0-indexed column's metadata as a map, or `nil` when unavailable ([#15]).
+- `pdo/statement-seq` - expose a statement's rows as a lazy seq of maps (the Phel-idiomatic take on `PDOStatement::getIterator`), so callers can `map`/`reduce`/`take` without materialising the whole result set ([#16]).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Returned by `pdo/query` and `pdo/prepare`.
 | `fetch-all` | `(fetch-all stmt)` | Remaining rows as a vector of maps. |
 | `fetch-column` | `(fetch-column stmt & [column])` | Single column from the next row. |
 | `fetch-object` | `(fetch-object stmt & [class-name ctor-args])` | Next row as an object (`stdClass` by default, or an instance of `class-name`), or `nil` if exhausted. |
+| `statement-seq` | `(statement-seq stmt)` | Lazy seq of the remaining rows as maps, fetched one at a time. |
 | `bind-value` | `(bind-value stmt column value & [type])` | Bind a value to a placeholder. Returns the statement. |
 | `bind-param` | `(bind-param stmt column value & [type])` | Bind a parameter, applied at execution time. Returns the statement. |
 | `column-count` | `(column-count stmt)` | Number of columns in the result set. |

--- a/src/pdo/statement.phel
+++ b/src/pdo/statement.phel
@@ -21,6 +21,13 @@
   [stmt]
   (map row->map (php/-> (stmt :stmt) (fetchAll \PDO/FETCH_ASSOC))))
 
+(defn statement-seq
+  "Returns a lazy seq of the statement's remaining rows as maps, fetched one at a time"
+  [stmt]
+  (lazy-seq
+   (when-let [row (fetch stmt)]
+     (cons row (statement-seq stmt)))))
+
 (defn fetch-object
   "Fetches the next row as an object (stdClass by default, or an instance of class-name), or nil if no more rows"
   [stmt & [class-name ctor-args]]
@@ -94,5 +101,4 @@
 ;; Not implemented yet:
 ;;
 ;; PDOStatement::bindColumn      — Bind a column to a PHP variable
-;; PDOStatement::getIterator     — Gets result set iterator
 ;; PDOStatement::nextRowset      — Advances to the next rowset in a multi-rowset statement handle

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -123,6 +123,21 @@
   (let [stmt (pdo/query *conn* "select * from t1 where id = 999")]
     (is (nil? (pdo/fetch-object stmt)))))
 
+(deftest statement-seq-yields-rows-as-maps
+  (create-t1 *conn*)
+  (insert-name *conn* "phel")
+  (insert-name *conn* "php")
+  (let [stmt (pdo/query *conn* "select * from t1")]
+    (is (= [{:id 1 :name "phel"} {:id 2 :name "php"}]
+           (into [] (pdo/statement-seq stmt))))))
+
+(deftest statement-seq-is-lazy-first-only-fetches-head
+  (create-t1 *conn*)
+  (insert-name *conn* "phel")
+  (insert-name *conn* "php")
+  (let [stmt (pdo/query *conn* "select * from t1")]
+    (is (= {:id 1 :name "phel"} (first (pdo/statement-seq stmt))))))
+
 (deftest column-count-on-select
   (seed-t1 *conn*)
   (let [stmt (pdo/query *conn* "select * from t1")]


### PR DESCRIPTION
Wraps the intent of `PDOStatement::getIterator` as `pdo/statement-seq`: a **lazy seq** of the statement's remaining rows as maps, fetched one row at a time.

```phel
(->> (pdo/query conn "select * from big")
     (pdo/statement-seq)
     (map :name)
     (take 10))   ;; only 10 rows are fetched
```

### Return-shape decision (per #16)
Returning the raw PHP `Iterator` would force callers into `php/->`, and an eager vector would just duplicate `fetch-all`. Instead `statement-seq` is built on `lazy-seq` + the existing `fetch`, so:
- it is genuinely lazy - `(first ...)` / `(take n ...)` only fetch what they consume;
- rows are keywordised maps via `row->map`, consistent with `fetch`/`fetch-all` (and with a stable `FETCH_ASSOC`, unlike a raw iterator whose shape depends on the fetch mode).

- Removed `getIterator` from the "Not implemented yet" block in `src/pdo/statement.phel`.
- Tests: `statement-seq-yields-rows-as-maps` (full realisation) and `statement-seq-is-lazy-first-only-fetches-head` (`first` realises just the head).
- README API table + CHANGELOG `## [Unreleased]` updated.

Polish pass: no refactor needed - composes `lazy-seq` + `fetch` + `cons`, no new state.

`composer test` green (49 assertions).

Closes #16