### PR TITLE
feat(pdo): add from-connection to wrap an existing PDO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pdo/statement-seq` - expose a statement's rows as a lazy seq of maps (the Phel-idiomatic take on `PDOStatement::getIterator`), so callers can `map`/`reduce`/`take` without materialising the whole result set ([#16]).
 - `pdo/next-rowset` - wrap `PDOStatement::nextRowset`; advances a multi-rowset statement (e.g. stored procedures on MySQL/Postgres) ([#17]).
 - `pdo/with-transaction` macro - runs a body in a transaction, committing on success (returning the last body value) and rolling back + re-throwing on error; runs inline when already in a transaction ([#20]).
+- `pdo/from-connection` - wrap an already-open `\PDO` (e.g. a Symfony/Doctrine DBAL connection) as a phel-pdo connection, reusing the host's handle as-is; `{:apply-defaults true}` opts into `ERRMODE_EXCEPTION` ([#21]).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All functions live in the `phel.pdo` namespace.
 | Function | Signature | Description |
 |---|---|---|
 | `connect` | `(connect dsn & [username password options])` | Open a connection. Throws `PDOException` on failure. Sets `ERRMODE_EXCEPTION` by default. |
+| `from-connection` | `(from-connection pdo & [options])` | Wrap an already-open `\PDO` (e.g. a framework/DBAL connection) as-is. `{:apply-defaults true}` sets `ERRMODE_EXCEPTION`. |
 | `exec` | `(exec conn sql)` | Execute SQL, return number of affected rows. |
 | `query` | `(query conn sql & [fetch-mode])` | Run SQL without placeholders, return a statement. |
 | `prepare` | `(prepare conn sql & [options])` | Prepare a statement for later `execute`. |

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -7,6 +7,29 @@ Common patterns. Every snippet assumes:
 (def conn (pdo/connect "sqlite::memory:"))
 ```
 
+## Reuse an existing (framework) connection
+
+Inside a PHP host (Symfony, Laravel) the app already has a configured, pooled
+connection. Hand its native `\PDO` to `from-connection` instead of opening a
+second one - Doctrine DBAL exposes it via `getNativeConnection()`:
+
+```clojure
+;; php-pdo is a \PDO passed in from the host framework
+(def conn (pdo/from-connection php-pdo))
+
+(-> (pdo/query conn "select * from products where id = 1")
+    (pdo/fetch))
+```
+
+`from-connection` reuses the handle as-is and leaves its attributes untouched -
+the host owns the connection's configuration, and phel-pdo never closes a
+connection it did not open. Pass `{:apply-defaults true}` to opt into
+phel-pdo's `ERRMODE_EXCEPTION`:
+
+```clojure
+(def conn (pdo/from-connection php-pdo {:apply-defaults true}))
+```
+
 ## Prepared statements
 
 Reuse a statement across many parameter sets:

--- a/src/pdo.phel
+++ b/src/pdo.phel
@@ -27,6 +27,17 @@
     (set-attribute conn \PDO/ATTR_ERRMODE \PDO/ERRMODE_EXCEPTION)
     conn))
 
+(defn from-connection
+  "Wraps an already-open \\PDO instance in a connection, reusing it as-is.
+  The host owns the connection's configuration and lifecycle; phel-pdo never
+  closes a connection it did not open. Pass {:apply-defaults true} to set
+  phel-pdo's ERRMODE_EXCEPTION default on the wrapped handle."
+  [pdo & [options]]
+  (let [conn (connection pdo)]
+    (when (get options :apply-defaults)
+      (set-attribute conn \PDO/ATTR_ERRMODE \PDO/ERRMODE_EXCEPTION))
+    conn))
+
 (defn ^int exec
   "Execute an SQL statement and return the number of affected rows"
   [conn stmt]

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -41,6 +41,33 @@
   (pdo/set-attribute *conn* \PDO/ATTR_ERRMODE \PDO/ERRMODE_SILENT)
   (is (= \PDO/ERRMODE_SILENT (pdo/get-attribute *conn* \PDO/ATTR_ERRMODE))))
 
+(deftest from-connection-wraps-existing-pdo
+  (let [raw  (php/new \PDO "sqlite::memory:")
+        conn (pdo/from-connection raw)]
+    (pdo/exec conn "create table t1 (id integer primary key autoincrement, name varchar(10))")
+    (pdo/exec conn "insert into t1 (name) values ('phel')")
+    (is (= {:id 1 :name "phel"} (pdo/fetch (pdo/query conn "select * from t1 where id = 1"))))))
+
+(deftest from-connection-supports-transactions
+  (let [raw  (php/new \PDO "sqlite::memory:")
+        conn (pdo/from-connection raw)]
+    (pdo/exec conn "create table t1 (id integer, name varchar(10))")
+    (pdo/with-transaction conn
+                          (pdo/exec conn "insert into t1 values (1, 'phel')"))
+    (is (= 1 (pdo/fetch-column (pdo/query conn "select count(*) from t1"))))))
+
+(deftest from-connection-leaves-attributes-untouched-by-default
+  (let [raw (php/new \PDO "sqlite::memory:")]
+    (php/-> raw (setAttribute \PDO/ATTR_ERRMODE \PDO/ERRMODE_SILENT))
+    (let [conn (pdo/from-connection raw)]
+      (is (= \PDO/ERRMODE_SILENT (pdo/get-attribute conn \PDO/ATTR_ERRMODE))))))
+
+(deftest from-connection-apply-defaults-sets-errmode-exception
+  (let [raw (php/new \PDO "sqlite::memory:")]
+    (php/-> raw (setAttribute \PDO/ATTR_ERRMODE \PDO/ERRMODE_SILENT))
+    (let [conn (pdo/from-connection raw {:apply-defaults true})]
+      (is (= \PDO/ERRMODE_EXCEPTION (pdo/get-attribute conn \PDO/ATTR_ERRMODE))))))
+
 (deftest available-drivers-includes-sqlite
   (is (contains-value? (pdo/get-available-drivers *conn*) "sqlite")))
 


### PR DESCRIPTION
Adds `pdo/from-connection` so Phel can reuse a host framework's already-open `\PDO` (Symfony/Laravel + Doctrine DBAL's `getNativeConnection()`) instead of opening a second connection:

```phel
(def conn (pdo/from-connection php-pdo))
(-> (pdo/query conn "select * from products where id = 1") (pdo/fetch))
```

Behaviour (per #21):
- Returns the standard `connection` value, so every downstream fn (`query`, `prepare`, `execute`, `fetch`, `insert`, `begin`/`commit`/`rollback`, `with-transaction`, ...) works unchanged.
- **Leaves attributes untouched by default** - the host owns the connection's configuration. `{:apply-defaults true}` opts into phel-pdo's `ERRMODE_EXCEPTION`.
- **Lifecycle**: phel-pdo never closes a connection it did not open (the library exposes no close, so a wrapped handle is never closed by it).

- Tests: wrap a pre-opened in-memory SQLite `\PDO` and run query/fetch; run a `with-transaction`; verify default leaves `ERRMODE` as set by the host (SILENT preserved) and `:apply-defaults` forces `ERRMODE_EXCEPTION`.
- README API table + `docs/recipes.md` "reuse an existing (framework) connection" section + CHANGELOG updated.

Polish pass: no refactor needed - reuses the `connection` struct and `set-attribute`; no duplication.

`composer test` green (60 assertions).

Closes #21