### PR TITLE
ref(pdo): fix boundary/coercion bugs and polish wrapper DX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pdo/get-attribute` / `pdo/set-attribute` now dispatch on the handle: pass a connection (as before) or a statement to reach `PDOStatement::getAttribute` / `setAttribute` ([#12]).
 - `pdo/error-code` / `pdo/error-info` now dispatch on the handle: pass a statement to read `PDOStatement::errorCode` / `errorInfo` ([#14]).
+- **BC** `pdo/error-code` now returns the SQLSTATE **string** (e.g. `"23000"`, `"HY000"`) instead of an int, and `pdo/error-info`'s first element is likewise the SQLSTATE string (the `driver-code` second element stays an int). SQLSTATE is a 5-character code; the old `intval` corrupted non-numeric states like `HY000` (→ `0`) and `42S02` (→ `42`).
+- **BC** `pdo/last-insert-id` and `pdo/insert` now return the id as a **string** (as PDO reports it) instead of coercing to int. This is lossless for big integers and PostgreSQL named sequences; call `php/intval` at the call site if you need a number.
+- **BC** `pdo/get-available-drivers` no longer takes a connection argument - `PDO::getAvailableDrivers` is static. Call `(pdo/get-available-drivers)`.
+
+### Fixed
+
+- `pdo/connect` and `pdo/prepare` now convert a Phel options map (with integer `\PDO/ATTR_*` keys) into a PHP array; previously passing an options map raised a `TypeError` because `phel->php` cannot convert integer map keys.
+- `pdo/bind-value` / `pdo/bind-param` now keep an integer `column` as a 1-based positional index instead of stringifying it, fixing positional (`?`) parameter binding.
+- `pdo/insert` now rejects an empty `row` map with an `InvalidArgumentException` instead of generating invalid SQL.
+- `pdo/set-fetch-mode` now throws an `InvalidArgumentException` on unsupported arity (more than 2 extra args) instead of silently doing nothing.
 
 ## [0.1.0] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Requires PHP `>=8.4` and `phel-lang/phel-lang ^0.37`.
 
 ;; Insert a row from a map
 (pdo/insert conn :t1 {:name "lisp"})
-;; => 3   ; new last-insert-id
+;; => "3"   ; new last-insert-id (string, as PDO reports it)
 ```
 
 `pdo/fetch` returns the row as a map keyed by column keyword, or `nil` when no rows remain.
@@ -74,15 +74,15 @@ All functions live in the `phel.pdo` namespace.
 | `exec` | `(exec conn sql)` | Execute SQL, return number of affected rows. |
 | `query` | `(query conn sql & [fetch-mode])` | Run SQL without placeholders, return a statement. |
 | `prepare` | `(prepare conn sql & [options])` | Prepare a statement for later `execute`. |
-| `insert` | `(insert conn table row)` | Insert `row` into `table` via a prepared statement and return the new `last-insert-id`. Identifiers must match `[A-Za-z_][A-Za-z0-9_]*`. |
+| `insert` | `(insert conn table row)` | Insert a non-empty `row` map into `table` via a prepared statement and return the new `last-insert-id` (string). Identifiers must match `[A-Za-z_][A-Za-z0-9_]*`. |
 | `quote` | `(quote conn string & [type])` | Quote a string for safe embedding in SQL. |
-| `last-insert-id` | `(last-insert-id conn)` | ID of the last inserted row. |
+| `last-insert-id` | `(last-insert-id conn)` | ID of the last inserted row, as a string (as PDO reports it). |
 | `begin` / `commit` / `rollback` | `(begin conn)` … | Transaction control. |
 | `in-transaction` | `(in-transaction conn)` | `true` if a transaction is active. |
 | `with-transaction` | `(with-transaction conn & body)` | Run `body` in a transaction: commit + return last value, or rollback + re-throw. Runs inline if already in a transaction. |
 | `get-attribute` / `set-attribute` | `(get-attribute handle attr)` / `(set-attribute handle attr value)` | PDO attribute access; `handle` is a connection or a statement. |
-| `get-available-drivers` | `(get-available-drivers conn)` | Vector of installed PDO drivers. |
-| `error-code` | `(error-code handle)` | SQLSTATE of the last operation; `handle` is a connection or a statement. |
+| `get-available-drivers` | `(get-available-drivers)` | Vector of installed PDO drivers (static; no connection needed). |
+| `error-code` | `(error-code handle)` | SQLSTATE string of the last operation; `handle` is a connection or a statement. |
 | `error-info` | `(error-info handle)` | `[sqlstate driver-code driver-message]`; `handle` is a connection or a statement. |
 
 ### Statement

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -115,10 +115,12 @@ Check state with `(pdo/in-transaction conn)`.
 ```clojure
 (pdo/exec conn "insert into t1 (name) values ('phel')")
 (pdo/last-insert-id conn)
-;; => 1
+;; => "1"
 ```
 
-Returns an `int`. On PostgreSQL pass the sequence name to raw PDO (not yet wrapped - drop into `(php/-> (conn :pdo) (lastInsertId "seq"))` for now).
+Returns a `string` (as PDO reports it) - lossless for big integers and named
+sequences; coerce with `php/intval` when you need a number. On PostgreSQL pass the
+sequence name to raw PDO (not yet wrapped - drop into `(php/-> (conn :pdo) (lastInsertId "seq"))` for now).
 
 ## Quoting
 
@@ -140,11 +142,11 @@ Pass a type as the third arg if you need something other than `PARAM_STR`.
   (pdo/exec conn "insert into t1 (id, name) values (1, 'dup')")
   (catch \PDOException _e nil))
 
-(pdo/error-code conn)   ; => 23000
-(pdo/error-info conn)   ; => [23000 19 "UNIQUE constraint failed: t1.id"]
+(pdo/error-code conn)   ; => "23000"
+(pdo/error-info conn)   ; => ["23000" 19 "UNIQUE constraint failed: t1.id"]
 ```
 
-`error-info` returns `[sqlstate driver-code driver-message]` with the first two coerced to int.
+`error-code` returns the SQLSTATE string. `error-info` returns `[sqlstate driver-code driver-message]` - `sqlstate` is the SQLSTATE string, `driver-code` the driver-specific integer.
 
 ## Attributes
 
@@ -160,7 +162,7 @@ Read or change PDO attributes per connection:
 ## Available drivers
 
 ```clojure
-(pdo/get-available-drivers conn)
+(pdo/get-available-drivers)
 ;; => ["mysql" "sqlite" ...]
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,13 +83,15 @@ phel-pdo sets `ERRMODE_EXCEPTION` in `connect`. If you've overridden it:
 
 …then errors go silent. Either revert it (`\PDO/ERRMODE_EXCEPTION`) or read `pdo/error-code` / `pdo/error-info` after every call. The default is the saner mode for almost every app.
 
-## `last-insert-id` returns 0 on PostgreSQL
+## `last-insert-id` is wrong on PostgreSQL
 
 PostgreSQL needs the sequence name. The wrapped `pdo/last-insert-id` calls `lastInsertId()` with no args. Until a sequence-aware wrapper lands, drop down to raw PDO:
 
 ```clojure
-(php/intval (php/-> (conn :pdo) (lastInsertId "t1_id_seq")))
+(php/-> (conn :pdo) (lastInsertId "t1_id_seq"))   ; => "42" (string)
 ```
+
+`pdo/last-insert-id` returns the value as a string (as PDO does); coerce with `php/intval` only when you actually need a number.
 
 ## Method I want isn't wrapped
 

--- a/src/pdo.phel
+++ b/src/pdo.phel
@@ -9,6 +9,13 @@
   [handle]
   (if (statement? handle) (handle :stmt) (handle :pdo)))
 
+(defn- options->php
+  "Builds a PHP array from a Phel options map. Unlike phel->php it preserves
+  integer keys, which PDO attribute maps use (e.g. \\PDO/ATTR_TIMEOUT)."
+  [options]
+  (apply php-associative-array
+         (mapcat (fn [[k v]] [k (phel->php v)]) options)))
+
 (defn ^bool set-attribute
   "Set an attribute on a connection or statement"
   [handle attribute value]
@@ -23,7 +30,7 @@
   "Connect database and return connection object.
   Throws a PDOException if the attempt to connect to the requested database fails."
   [dsn & [username password options]]
-  (let [conn (connection (php/new \PDO dsn username password options))]
+  (let [conn (connection (php/new \PDO dsn username password (options->php (or options {}))))]
     (set-attribute conn \PDO/ATTR_ERRMODE \PDO/ERRMODE_EXCEPTION)
     conn))
 
@@ -33,6 +40,8 @@
   closes a connection it did not open. Pass {:apply-defaults true} to set
   phel-pdo's ERRMODE_EXCEPTION default on the wrapped handle."
   [pdo & [options]]
+  (when-not (php/instanceof pdo \PDO)
+    (throw (php/new \InvalidArgumentException "from-connection expects a \\PDO instance")))
   (let [conn (connection pdo)]
     (when (get options :apply-defaults)
       (set-attribute conn \PDO/ATTR_ERRMODE \PDO/ERRMODE_EXCEPTION))
@@ -50,7 +59,7 @@
   "Prepares a statement for execution and returns a statement object"
   [conn stmt & [options]]
   (statement
-   (php/-> (conn :pdo) (prepare stmt (phel->php (or options {}))))))
+   (php/-> (conn :pdo) (prepare stmt (options->php (or options {}))))))
 
 (defn query
   "Prepares and executes an SQL statement without placeholders"
@@ -78,10 +87,12 @@
   [conn string & [type]]
   (php/-> (conn :pdo) (quote string (or type \PDO/PARAM_STR))))
 
-(defn ^int last-insert-id
-  "Returns the ID of the last inserted row or sequence value"
+(defn ^string last-insert-id
+  "Returns the ID of the last inserted row or sequence value, as a string (as PDO
+  reports it). Returning the raw string is lossless for big integers and named
+  sequences; coerce with php/intval at the call site when you need a number"
   [conn]
-  (php/intval (php/-> (conn :pdo) (lastInsertId))))
+  (php/-> (conn :pdo) (lastInsertId)))
 
 (defn- check-ident [s]
   (if (= 1 (php/preg_match "/^[A-Za-z_][A-Za-z0-9_]*$/" s))
@@ -91,10 +102,13 @@
 (defn- join-csv [xs]
   (php/implode ", " (phel->php (into [] xs))))
 
-(defn ^int insert
-  "Inserts a row built from a map into table and returns the new last-insert-id.
-  Table and column names must be plain identifiers; values are bound as parameters."
+(defn ^string insert
+  "Inserts a row built from a map into table and returns the new last-insert-id
+  (a string, as PDO reports it). Table and column names must be plain identifiers;
+  values are bound as parameters."
   [conn table row]
+  (when (empty? row)
+    (throw (php/new \InvalidArgumentException "insert row map must not be empty")))
   (let [tbl  (check-ident (name table))
         cols (into [] (for [k :in (keys row)] (check-ident (name k))))
         sql  (str "INSERT INTO " tbl
@@ -103,17 +117,20 @@
     (-> (prepare conn sql) (execute row))
     (last-insert-id conn)))
 
-(defn ^int error-code
-  "Fetch the SQLSTATE associated with the last operation on a connection or statement"
+(defn ^string error-code
+  "Fetch the SQLSTATE associated with the last operation on a connection or statement.
+  SQLSTATE is a 5-character code (e.g. \"23000\", \"HY000\"), returned as a string"
   [handle]
-  (php/intval (php/-> (handle-target handle) (errorCode))))
+  (php/-> (handle-target handle) (errorCode)))
 
 (defn error-info
-  "Fetch extended error information associated with the last operation on a connection or statement"
+  "Fetch extended error information associated with the last operation on a connection
+  or statement, as [sqlstate driver-code driver-message]. sqlstate is the SQLSTATE
+  string; driver-code is the driver-specific integer"
   [handle]
   (let [[sqlstate driver-code driver-message]
         (values (php->phel (php/-> (handle-target handle) (errorInfo))))]
-    [(php/intval sqlstate) (php/intval driver-code) driver-message]))
+    [sqlstate (php/intval driver-code) driver-message]))
 
 (defn ^bool in-transaction
   "Checks if inside a transaction"
@@ -139,8 +156,9 @@
              (throw e#)))))))
 
 (defn get-available-drivers
-  "Return an array of available PDO drivers"
-  [conn]
-  (values (php->phel (php/-> (conn :pdo) (getAvailableDrivers)))))
+  "Return a vector of available PDO driver names. PDO::getAvailableDrivers is
+  static, so no connection is needed"
+  []
+  (values (php->phel (php/:: \PDO (getAvailableDrivers)))))
 
 (load "pdo/statement")

--- a/src/pdo/statement.phel
+++ b/src/pdo/statement.phel
@@ -12,17 +12,20 @@
     (row->map row)))
 
 (defn fetch-column
-  "Returns a single column from the next row of a result set"
+  "Returns a single column from the next row of a result set. Returns false when
+  the cursor is exhausted (PDO's sentinel); a nil means the column was SQL NULL"
   [stmt & [column]]
   (php/-> (stmt :stmt) (fetchColumn (or column 0))))
 
 (defn fetch-all
-  "Fetches the remaining rows from a result set"
+  "Fetches the remaining rows from a result set as a seq of maps"
   [stmt]
-  (map row->map (php/-> (stmt :stmt) (fetchAll \PDO/FETCH_ASSOC))))
+  (map row->map (or (php/-> (stmt :stmt) (fetchAll \PDO/FETCH_ASSOC)) [])))
 
 (defn statement-seq
-  "Returns a lazy seq of the statement's remaining rows as maps, fetched one at a time"
+  "Returns a lazy seq of the statement's remaining rows as maps, fetched one at a
+  time. The cursor stays open until the seq is fully consumed; on drivers with
+  cursor limits, realise it fully or call close-cursor when done early"
   [stmt]
   (lazy-seq
    (when-let [row (fetch stmt)]
@@ -51,19 +54,25 @@
   stmt)
 
 (defn ^bool next-rowset
-  "Advances to the next rowset of a multi-rowset statement; false when none remain"
+  "Advances to the next rowset of a multi-rowset statement; true when another
+  rowset is available, false when none remain. Throws PDOException on drivers
+  that don't support multiple rowsets (e.g. SQLite)"
   [stmt]
   (php/-> (stmt :stmt) (nextRowset)))
 
 (defn set-fetch-mode
   "Sets the default fetch mode for the statement. Extra args match the mode
-  (e.g. column index for FETCH_COLUMN, class name + ctor args for FETCH_CLASS)"
+  (e.g. column index for FETCH_COLUMN, class name + ctor args for FETCH_CLASS).
+  Note: fetch / fetch-all always request FETCH_ASSOC, so this default applies to
+  the statement's native iteration, not those wrappers"
   [stmt mode & args]
   (let [s (stmt :stmt)]
     (case (count args)
       0 (php/-> s (setFetchMode mode))
       1 (php/-> s (setFetchMode mode (phel->php (first args))))
-      2 (php/-> s (setFetchMode mode (phel->php (first args)) (phel->php (second args))))))
+      2 (php/-> s (setFetchMode mode (phel->php (first args)) (phel->php (second args))))
+      (throw (php/new \InvalidArgumentException
+                      (str "set-fetch-mode accepts at most 2 extra args, got " (count args))))))
   stmt)
 
 (defn ^int column-count
@@ -82,18 +91,26 @@
   (when-let [meta (php/-> (stmt :stmt) (getColumnMeta column))]
     (row->map meta)))
 
+(defn- param-key
+  "PDO parameter identifier: an integer is a 1-based positional index (kept as-is);
+  anything else is a named placeholder coerced to a string."
+  [column]
+  (if (int? column) column (str column)))
+
 (defn bind-value
-  "Binds a value to a parameter"
+  "Binds a value to a parameter (named placeholder or 1-based positional index)"
   [stmt column value & [type]]
   (php/-> (stmt :stmt)
-          (bindValue (str column) value (or type \PDO/PARAM_STR)))
+          (bindValue (param-key column) value (or type \PDO/PARAM_STR)))
   stmt)
 
 (defn bind-param
-  "Binds a parameter to a value, applied at execution time"
+  "Binds a value to a parameter. The value is captured at call time: Phel values
+  are immutable, so unlike PHP's by-reference bindParam there is nothing to mutate
+  before execute - for fresh values per run, re-bind or pass a params map to execute"
   [stmt column value & [type]]
   (php/-> (stmt :stmt)
-          (bindParam (str column) value (or type \PDO/PARAM_STR)))
+          (bindParam (param-key column) value (or type \PDO/PARAM_STR)))
   stmt)
 
 (defn ^string debug-dump-params

--- a/tests/pdo_test.phel
+++ b/tests/pdo_test.phel
@@ -15,7 +15,9 @@
   (pdo/exec conn "create table t1 (id integer primary key autoincrement, name varchar(10))"))
 
 (defn- insert-name [conn name]
-  (pdo/exec conn (format "insert into t1 (name) values ('%s')" name)))
+  (-> (pdo/prepare conn "insert into t1 (name) values (:name)")
+      (pdo/execute {:name name})
+      (pdo/row-count)))
 
 (defn- seed-t1
   "Create t1 with one row named 'phel'."
@@ -40,6 +42,13 @@
 (deftest attribute-roundtrip
   (pdo/set-attribute *conn* \PDO/ATTR_ERRMODE \PDO/ERRMODE_SILENT)
   (is (= \PDO/ERRMODE_SILENT (pdo/get-attribute *conn* \PDO/ATTR_ERRMODE))))
+
+(deftest connect-accepts-options-map
+  ;; options must be converted from a Phel map to a PHP array
+  (let [conn (pdo/connect "sqlite::memory:" nil nil {\PDO/ATTR_TIMEOUT 5})]
+    (is (struct? conn))
+    (pdo/exec conn "create table t1 (id integer)")
+    (is (= 1 (pdo/exec conn "insert into t1 values (1)")))))
 
 (deftest from-connection-wraps-existing-pdo
   (let [raw  (php/new \PDO "sqlite::memory:")
@@ -69,7 +78,7 @@
       (is (= \PDO/ERRMODE_EXCEPTION (pdo/get-attribute conn \PDO/ATTR_ERRMODE))))))
 
 (deftest available-drivers-includes-sqlite
-  (is (contains-value? (pdo/get-available-drivers *conn*) "sqlite")))
+  (is (contains-value? (pdo/get-available-drivers) "sqlite")))
 
 (deftest quote-escapes-single-quotes
   (is (= "'I''m fine.'" (pdo/quote *conn* "I'm fine."))))
@@ -87,7 +96,7 @@
 
 (deftest last-insert-id-reflects-last-row
   (seed-t1 *conn*)
-  (is (= 1 (pdo/last-insert-id *conn*))))
+  (is (= "1" (pdo/last-insert-id *conn*))))
 
 ;; ------------
 ;; Transactions
@@ -189,6 +198,11 @@
     (is (= [{:id 1 :name "phel"} {:id 2 :name "php"}]
            (into [] (pdo/statement-seq stmt))))))
 
+(deftest statement-seq-empty-result-is-empty-seq
+  (create-t1 *conn*)
+  (let [stmt (pdo/query *conn* "select * from t1")]
+    (is (= [] (into [] (pdo/statement-seq stmt))))))
+
 (deftest statement-seq-is-lazy-first-only-fetches-head
   (create-t1 *conn*)
   (insert-name *conn* "phel")
@@ -254,6 +268,14 @@
                  stmt (pdo/execute stmt)]
              (is (= {:id 1 :name "phel"} (pdo/fetch stmt))))))
 
+(deftest bind-value-by-positional-index
+  (seed-t1 *conn*)
+  ;; integer column is a 1-based positional placeholder, kept as an int (not "1")
+  (let [stmt (pdo/prepare *conn* "select * from t1 where id = ?")
+        stmt (pdo/bind-value stmt 1 1 \PDO/PARAM_INT)
+        stmt (pdo/execute stmt)]
+    (is (= {:id 1 :name "phel"} (pdo/fetch stmt)))))
+
 (deftest close-cursor-allows-re-execution
   (seed-t1 *conn*)
   (let [stmt (pdo/prepare *conn* "select name from t1 where id = :id")
@@ -263,6 +285,9 @@
         stmt (pdo/execute stmt {:id 1})]
     (is (= "phel" (pdo/fetch-column stmt)))))
 
+;; set-fetch-mode changes the statement's *native* default fetch mode. pdo/fetch
+;; and pdo/fetch-all always request FETCH_ASSOC, so the only way to observe the
+;; default is the raw PDOStatement::fetch - hence the (stmt :stmt) reach-through here.
 (deftest set-fetch-mode-column-returns-scalar
   (seed-t1 *conn*)
   (let [stmt (pdo/prepare *conn* "select name from t1")
@@ -286,6 +311,15 @@
                   (pdo/next-rowset stmt)
                   (catch \PDOException _e :unsupported))]
     (is (or (= false outcome) (= :unsupported outcome)))))
+
+(deftest set-fetch-mode-rejects-too-many-args
+  (seed-t1 *conn*)
+  (let [stmt   (pdo/prepare *conn* "select * from t1")
+        thrown (try
+                 (pdo/set-fetch-mode stmt \PDO/FETCH_CLASS "stdClass" [] :extra)
+                 false
+                 (catch \InvalidArgumentException _e true))]
+    (is (= true thrown))))
 
 (deftest set-attribute-dispatches-to-statement
   (seed-t1 *conn*)
@@ -323,7 +357,15 @@
 
 (deftest insert-returns-new-row-id
   (create-t1 *conn*)
-  (is (= 1 (pdo/insert *conn* :t1 {:name "phel"}))))
+  (is (= "1" (pdo/insert *conn* :t1 {:name "phel"}))))
+
+(deftest insert-rejects-empty-row
+  (create-t1 *conn*)
+  (let [thrown (try
+                 (pdo/insert *conn* :t1 {})
+                 false
+                 (catch \InvalidArgumentException _e true))]
+    (is (= true thrown))))
 
 (deftest insert-persists-row
   (create-t1 *conn*)
@@ -333,12 +375,12 @@
 
 (deftest insert-accepts-string-table
   (create-t1 *conn*)
-  (is (= 1 (pdo/insert *conn* "t1" {:name "phel"}))))
+  (is (= "1" (pdo/insert *conn* "t1" {:name "phel"}))))
 
 (deftest insert-monotonic-ids
   (create-t1 *conn*)
   (pdo/insert *conn* :t1 {:name "a"})
-  (is (= 2 (pdo/insert *conn* :t1 {:name "b"}))))
+  (is (= "2" (pdo/insert *conn* :t1 {:name "b"}))))
 
 (deftest insert-rejects-bad-table
   (create-t1 *conn*)
@@ -378,14 +420,14 @@
   (try
     (pdo/exec *conn* "insert into t1 (id, name) values (1, 'php')")
     (catch \PDOException _e nil))
-  (is (= 23000 (pdo/error-code *conn*))))
+  (is (= "23000" (pdo/error-code *conn*))))
 
 (deftest error-info-on-constraint-violation
   (seed-t1 *conn*)
   (try
     (pdo/exec *conn* "insert into t1 (id, name) values (1, 'php')")
     (catch \PDOException _e nil))
-  (is (= [23000 19 "UNIQUE constraint failed: t1.id"] (pdo/error-info *conn*))))
+  (is (= ["23000" 19 "UNIQUE constraint failed: t1.id"] (pdo/error-info *conn*))))
 
 (deftest statement-error-code-on-constraint-violation
   (seed-t1 *conn*)
@@ -393,7 +435,7 @@
     (try
       (pdo/execute stmt)
       (catch \PDOException _e nil))
-    (is (= 23000 (pdo/error-code stmt)))))
+    (is (= "23000" (pdo/error-code stmt)))))
 
 (deftest statement-error-info-on-constraint-violation
   (seed-t1 *conn*)
@@ -401,4 +443,4 @@
     (try
       (pdo/execute stmt)
       (catch \PDOException _e nil))
-    (is (= [23000 19 "UNIQUE constraint failed: t1.id"] (pdo/error-info stmt)))))
+    (is (= ["23000" 19 "UNIQUE constraint failed: t1.id"] (pdo/error-info stmt)))))


### PR DESCRIPTION
Whole-library bug hunt + quality pass over the new wrappers, driven by two independent reviews. Optimises for long-term DX; the breaking changes are intentional and documented.

## Bugs fixed
- **Options map → TypeError**: `connect` / `prepare` passed a Phel options map straight to PDO. `phel->php` *cannot convert integer map keys* (and PDO `ATTR_*` keys are integers), so any options map threw `TypeError` / `getName() on int`. New private `options->php` builds the PHP array key-safely. Regression test added.
- **Positional binding broken**: `bind-value` / `bind-param` did `(str column)`, turning positional index `1` into `"1"` — PDO then errors on `?` placeholders. Now an integer column is kept as a 1-based index (`param-key` helper). Test added.
- **`insert` on empty map**: produced `INSERT INTO t () VALUES ()` (SQL syntax error). Now throws `InvalidArgumentException` at the Phel boundary. Test added.
- **`set-fetch-mode` silent no-op**: `case` had no default, so >2 extra args returned `nil` and never called `setFetchMode`. Now throws `InvalidArgumentException`. Test added.

## Breaking changes (documented in CHANGELOG)
- **`error-code` → SQLSTATE string** (and `error-info`'s first element): `intval` corrupted non-numeric states (`HY000`→`0`, `42S02`→`42`). SQLSTATE is a 5-char code. `driver-code` stays int.
- **`last-insert-id` / `insert` → string id**: PDO reports it as a string; coercing to int loses big integers and PostgreSQL named sequences. Coerce with `php/intval` at the call site when needed.
- **`get-available-drivers` → no connection arg**: `PDO::getAvailableDrivers` is static; requiring a connection was a DX wart and blocked the pre-connection use case.

## DX / docs / tests
- `from-connection` rejects a non-`\PDO` with a clear error.
- `fetch-all` guards against a `false` return under silent error mode.
- Docstrings clarified: `bind-param` (value captured at call time, not by-ref), `statement-seq` (cursor stays open until consumed), `next-rowset` (throws on unsupported drivers), `fetch-column` (false-vs-nil), `set-fetch-mode` (fetch/fetch-all force FETCH_ASSOC).
- Test fixture `insert-name` now uses a prepared statement instead of string interpolation.
- README + `docs/recipes.md` + `docs/troubleshooting.md` updated for all signature/return changes.

`composer test` green (66 assertions, up from 60).

Aligns the library for a clean release.